### PR TITLE
Removing the 'about' annotation for topics

### DIFF
--- a/taxonomyService.go
+++ b/taxonomyService.go
@@ -9,7 +9,6 @@ type TaxonomyService interface {
 	buildSuggestions(ContentRef) []suggestion
 }
 
-const conceptAbout = "about"
 const conceptMentions = "mentions"
 
 const classification = "isClassifiedBy"

--- a/taxonomyService_test.go
+++ b/taxonomyService_test.go
@@ -204,16 +204,6 @@ func buildConceptSuggestions(subjectCount int, sectionCount int, topicCount int,
 		sectionSuggestion := suggestion{Thing: oneThing, Provenance: []provenance{metadataProvenance}}
 
 		suggestions = append(suggestions, sectionSuggestion)
-
-		oneThing = thing{
-			ID:        "http://api.ft.com/things/" + NewNameUUIDFromBytes([]byte(topicTMEIDs[i])).String(),
-			PrefLabel: topicNames[i],
-			Predicate: conceptAbout,
-			Types:     []string{topicURI},
-		}
-		sectionSuggestion = suggestion{Thing: oneThing, Provenance: []provenance{metadataProvenance}}
-
-		suggestions = append(suggestions, sectionSuggestion)
 	}
 
 	return suggestions

--- a/topicService.go
+++ b/topicService.go
@@ -15,7 +15,6 @@ func (topicService TopicService) buildSuggestions(contentRef ContentRef) []sugge
 
 	for _, value := range topics {
 		suggestions = append(suggestions, buildSuggestion(value, topicURI, conceptMentions))
-		suggestions = append(suggestions, buildSuggestion(value, topicURI, conceptAbout))
 	}
 
 	return suggestions


### PR DESCRIPTION
- shouldn't be on there for every topic
- primary theme isn't implemented yet, so we only have mentions for now
