### PR TITLE
changed taxonomy  name to AlphavilleSeriesClassification

### DIFF
--- a/app.go
+++ b/app.go
@@ -121,7 +121,7 @@ func setupTaxonomyHandlers() {
 	taxonomyHandlers["locations"] = LocationService{HandledTaxonomy: "gl"}
 	taxonomyHandlers["genres"] = GenreService{HandledTaxonomy: "genres"}
 	taxonomyHandlers["specialReports"] = SpecialReportService{HandledTaxonomy: "specialReports"}
-	taxonomyHandlers["alphavilleSeries"] = AlphavilleSeriesService{HandledTaxonomy: "alphavilleSeries"}
+	taxonomyHandlers["alphavilleSeries"] = AlphavilleSeriesService{HandledTaxonomy: "alphavilleSeriesClassification"}
 }
 
 func enableHealthChecks(srcConf consumer.QueueConfig, destConf producer.MessageProducerConfig) {


### PR DESCRIPTION
changed  taxonomy name for AlphavilleSeries  to  AlphavilleSeriesClassification  to fix the binding of av-concepts to blogs.
